### PR TITLE
Keep blocked page in history so that it can be accessed later

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,7 +6,7 @@
   "background": {
     "service_worker": "background/background.js"
   },
-  "permissions": ["storage", "tabs"],
+  "permissions": ["storage", "tabs", "history"],
   "action": {
     "default_popup": "popup/popup.html",
     "default_icon": {

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -1,8 +1,8 @@
 import {
+  ScheduleDataInterface,
   WebBlockerData,
   WebBlockerRedirect,
   WebBlockerSchedule,
-  ScheduleDataInterface,
   initSchedData,
 } from '../types/types';
 
@@ -101,14 +101,13 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
           const { hostname } = new URL(tab.url);
           let blocked = webBlockerData.WebsiteBlockerBlock.includes(hostname);
           if (blocked) {
-            console.log(blocked, 'blocked');
-            if (webBlockerRedirect.WebsiteBlockerRedirect) {
-              chrome.tabs.update(tabId, {
-                url: webBlockerRedirect.WebsiteBlockerRedirect,
-              });
-            } else {
-              chrome.tabs.update(tabId, { url: 'chrome://newtab' });
-            }
+            console.log(blocked, "blocked");
+            let newUrl = webBlockerRedirect.WebsiteBlockerRedirect ?? "chrome://newtab";
+
+            // tabs.update will not keep target URL in history so let's save it first
+            chrome.history.addUrl({ url: tab.url }).then(() => {
+              chrome.tabs.update(tabId, { url: newUrl });
+            });
           }
         }
       }


### PR DESCRIPTION
I've noticed that when opening links to pages that are on the blocklist the extension will kick in (as expected) but I will not be possible to retrieve the blocked URL later when block schedule would normally allow me to visit it.

I've added a call to `history.addUrl` so that the blocked page is still in history and can be accessed with `Back` button.